### PR TITLE
Added godot_print_rich! in log.rs

### DIFF
--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -67,7 +67,7 @@ macro_rules! godot_script_error {
 #[macro_export]
 macro_rules! godot_print {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
-        $crate::log::print(&[
+        $crate::log::print(false, &[
             $crate::builtin::Variant::from(
                 $crate::builtin::GString::from(
                     format!($fmt $(, $args)*)
@@ -77,15 +77,31 @@ macro_rules! godot_print {
     };
 }
 
-pub use crate::{godot_error, godot_print, godot_script_error, godot_warn};
+#[macro_export]
+macro_rules! godot_print_rich {
+    ($fmt:literal $(, $args:expr)* $(,)?) => {
+        $crate::log::print(true, &[
+            $crate::builtin::Variant::from(
+                $crate::builtin::GString::from(
+                    format!($fmt $(, $args)*)
+                )
+            )
+        ])
+    };
+}
+
+pub use crate::{godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn};
 
 use crate::builtin::{StringName, Variant};
 use crate::sys::{self, GodotFfi};
 
-/// Prints to the Godot console, used by the [`godot_print!`] macro.
-pub fn print(varargs: &[Variant]) {
+/// Prints to the Godot console, used by the [`godot_print!`] and  [`godot_print_rich!`] macros.
+pub fn print(use_bbcode: bool, varargs: &[Variant]) {
     unsafe {
-        let method_name = StringName::from("print");
+        let method_name = match use_bbcode {
+            false => StringName::from("print"),
+            true => StringName::from("print_rich"),
+        };
         let call_fn = sys::interface_fn!(variant_get_ptr_utility_function)(
             method_name.string_sys(),
             2648703342i64,

--- a/godot-core/src/log.rs
+++ b/godot-core/src/log.rs
@@ -67,41 +67,39 @@ macro_rules! godot_script_error {
 #[macro_export]
 macro_rules! godot_print {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
-        $crate::log::print(false, &[
+        $crate::log::print(&[
             $crate::builtin::Variant::from(
-                $crate::builtin::GString::from(
-                    format!($fmt $(, $args)*)
-                )
+                format!($fmt $(, $args)*)
             )
         ])
     };
 }
 
+
+/// Prints to the Godot console. Supports BBCode, color and URL tags. Slower than godot_print! (typically twice as slow or worse).
+///
+/// _Godot equivalent: [`@GlobalScope.print_rich()`](https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#class-globalscope-method-print-rich)_.
 #[macro_export]
 macro_rules! godot_print_rich {
     ($fmt:literal $(, $args:expr)* $(,)?) => {
-        $crate::log::print(true, &[
+        $crate::log::print_rich(&[
             $crate::builtin::Variant::from(
-                $crate::builtin::GString::from(
-                    format!($fmt $(, $args)*)
-                )
+                format!($fmt $(, $args)*)
             )
         ])
     };
 }
+
 
 pub use crate::{godot_error, godot_print, godot_print_rich, godot_script_error, godot_warn};
 
 use crate::builtin::{StringName, Variant};
 use crate::sys::{self, GodotFfi};
 
-/// Prints to the Godot console, used by the [`godot_print!`] and  [`godot_print_rich!`] macros.
-pub fn print(use_bbcode: bool, varargs: &[Variant]) {
+/// Prints to the Godot console, used by the [`godot_print!`] macro.
+pub fn print(varargs: &[Variant]) {
     unsafe {
-        let method_name = match use_bbcode {
-            false => StringName::from("print"),
-            true => StringName::from("print_rich"),
-        };
+        let method_name = StringName::from("print");
         let call_fn = sys::interface_fn!(variant_get_ptr_utility_function)(
             method_name.string_sys(),
             2648703342i64,
@@ -119,4 +117,27 @@ pub fn print(use_bbcode: bool, varargs: &[Variant]) {
 
     // TODO use generated method, but figure out how print() with zero args can be called
     // crate::engine::utilities::print(head, rest);
+}
+
+/// Prints to the Godot console, used by the [`godot_print_rich!`] macro.
+pub fn print_rich(varargs: &[Variant]) {
+    unsafe {
+        let method_name = StringName::from("print_rich");
+        let call_fn = sys::interface_fn!(variant_get_ptr_utility_function)(
+            method_name.string_sys(),
+            2648703342i64,
+        );
+        let call_fn = call_fn.unwrap_unchecked();
+
+        let mut args = Vec::new();
+        args.extend(varargs.iter().map(Variant::sys_const));
+
+        let args_ptr = args.as_ptr();
+        let _variant = Variant::from_sys_init_default(|return_ptr| {
+            call_fn(return_ptr, args_ptr, args.len() as i32);
+        });
+    }
+
+    // TODO use generated method, but figure out how print_rich() with zero args can be called
+    // crate::engine::utilities::print_rich(head, rest);
 }


### PR DESCRIPTION
Related to #624. Added a new godot_print_rich! macro. The impact on existing code is that godot_print! adds one more boolean parameter when calling the internal print() function (which uses the boolean to select the print or print_rich godot API function).